### PR TITLE
feat(core): Add configuration validation on startup

### DIFF
--- a/tests/routes/test_validator.py
+++ b/tests/routes/test_validator.py
@@ -1,0 +1,132 @@
+from os import environ as env
+import unittest
+from webhook_gateway.routes.route import Route
+
+from webhook_gateway.routes.validator import validate_config, validate_route
+from webhook_gateway.exceptions import ConfigurationException
+
+
+class ConfigurationValidatorTest(unittest.TestCase):
+    def test_validate_config_str_novariable(self):
+        validate_config("testroute", "teststring", ["my_var_1", "my_var_2"])
+
+    def test_validate_config_str_withvariable_env_known(self):
+        env["knownvariable"] = "varvalue"
+        validate_config(
+            "testroute",
+            "blablabla #env[knownvariable] blablabla",
+            ["my_var_1", "my_var_2"],
+        )
+        env.pop("knownvariable")
+
+    def test_validate_config_str_withvariable_env_unknown(self):
+        with self.assertRaises(ConfigurationException):
+            validate_config(
+                "testroute",
+                "blablabla #env[unknownvariable] blablabla",
+                ["my_var_1", "my_var_2"],
+            )
+
+    def test_validate_config_str_withvariable_context_known(self):
+        validate_config(
+            "testroute",
+            "blablabla #context[knownvariable] blablabla",
+            ["knownvariable", "my_var_2"],
+        )
+
+    def test_validate_config_str_nospace_withvariable_context_known(self):
+        validate_config(
+            "testroute",
+            "blablabla#context[knownvariable]blablabla",
+            ["knownvariable", "my_var_2"],
+        )
+
+    def test_validate_config_str_withvariable_context_unknown(self):
+        with self.assertRaises(ConfigurationException):
+            validate_config(
+                "testroute",
+                "blablabla #context[unknownvariable] blablabla",
+                ["knownvariable", "my_var_2"],
+            )
+
+    def test_validate_config_dict_knownvars(self):
+        env["knownvariable"] = "varvalue"
+        obj = {
+            "key": "value",
+            "key2": {"key21": "blablabla#env[knownvariable]blablabla"},
+            "key3": "blablabla#context[knownvariable]blablabla",
+        }
+        validate_config("testrule", obj, ["knownvariable", "my_var_2"])
+        env.pop("knownvariable")
+
+    def test_validate_config_dict_unknown_envvar(self):
+        obj = {
+            "key": "value",
+            "key2": {"key21": "blablabla#env[unknownvariable]blablabla"},
+            "key3": "blablabla#context[knownvariable]blablabla",
+        }
+        with self.assertRaises(ConfigurationException):
+            validate_config("testrule", obj, ["knownvariable", "my_var_2"])
+
+    def test_validate_config_dict_unknown_contextvar(self):
+        env["knownvariable"] = "varvalue"
+        obj = {
+            "key": "value",
+            "key2": {"key21": "blablabla#env[knownvariable]blablabla"},
+            "key3": "blablabla#context[unknownvariable]blablabla",
+        }
+        with self.assertRaises(ConfigurationException):
+            validate_config("testrule", obj, ["knownvariable", "my_var_2"])
+        env.pop("knownvariable")
+
+
+class ConfigurationRouteValidatorTest(unittest.TestCase):
+    def create_route(
+        self, auth_headers: dict = None, input_body: dict = None, output: dict = None
+    ):
+        route = {
+            "auth_headers": {"X-Api-Token": "MySuperToken"},
+            "input": {
+                "body": {
+                    "$.num": {"equalsTo": "12345", "context_variable": "TICKET_NUM"}
+                }
+            },
+            "output": [
+                {
+                    "name": "gitlab",
+                    "url": "https://gitlab.com/api/v4/projects/lgatellier%2Ftest/issues",
+                    "headers": {"Private-Token": "#env[GITLAB_API_TOKEN]"},
+                    "body": {"title": "Océane #context[TICKET_NUM]"},
+                    "context_variables": {"$.id": "GITLAB_ISSUE_ID"},
+                }
+            ],
+        }
+        if auth_headers:
+            route["auth_headers"].update(auth_headers)
+        if input_body:
+            route["input"]["body"].update(input_body)
+        if output:
+            route["output"][0].update(output)
+
+        return Route("testroute", route)
+
+    def test_validate_route_passing(self):
+        env["GITLAB_API_TOKEN"] = "thisisasupertoken"
+        validate_route(self.create_route())
+        env.pop("GITLAB_API_TOKEN")
+
+    def test_validate_route_call_unknown_context_variable(self):
+        env["GITLAB_API_TOKEN"] = "thisisasupertoken"
+        with self.assertRaises(ConfigurationException):
+            validate_route(
+                self.create_route(
+                    output={"body": {"title": "Océane #context[UNKNOWN_VAR]"}}
+                )
+            )
+        env.pop("GITLAB_API_TOKEN")
+
+    def test_validate_route_call_unknown_env_variable(self):
+        if "GITLAB_API_TOKEN" in env:
+            env.pop("GITLAB_API_TOKEN")
+        with self.assertRaises(ConfigurationException):
+            validate_route(self.create_route())

--- a/webhook_gateway/configuration.py
+++ b/webhook_gateway/configuration.py
@@ -1,8 +1,11 @@
 from dependency_injector import containers, providers
 import logging
 import os
+from dependency_injector.wiring import Provide, inject
+from fastapi.param_functions import Depends
 import yaml
 
+from .routes.service import RouteService
 from . import routes
 
 
@@ -17,6 +20,13 @@ class WebhookGatewayConfig(containers.DeclarativeContainer):
     routes_service = providers.Singleton(routes.RouteService, config.config_file)
 
     wiring_config = containers.WiringConfiguration(modules=[".main"])
+
+
+@inject
+def validate_config(
+    routes: RouteService = Depends(Provide[WebhookGatewayConfig.routes_service]),
+):
+    routes.validate_routes()
 
 
 def setup_logging(

--- a/webhook_gateway/exceptions.py
+++ b/webhook_gateway/exceptions.py
@@ -14,3 +14,7 @@ class UnauthorizedAccessException(HTTPExceptionWithParameters):
 
     def __init__(self, message, *parameters) -> None:
         super().__init__(message, *parameters, http_status=401)
+
+
+class ConfigurationException(Exception):
+    pass

--- a/webhook_gateway/main.py
+++ b/webhook_gateway/main.py
@@ -1,6 +1,6 @@
 import logging
 
-from .configuration import WebhookGatewayConfig, setup_logging
+from .configuration import WebhookGatewayConfig, setup_logging, validate_config
 from . import __version__, api
 
 setup_logging()
@@ -11,3 +11,4 @@ logger.info(f"Starting up webhook_gateway {__version__}")
 app = api.api
 app.configuration = WebhookGatewayConfig()
 app.configuration.wire(modules=[".api"])
+validate_config()

--- a/webhook_gateway/routes/route.py
+++ b/webhook_gateway/routes/route.py
@@ -28,6 +28,14 @@ class Route:
     def config(self) -> dict:
         return self.__config
 
+    @property
+    def input_rules(self):
+        return self.__input_rules
+
+    @property
+    def output_rules(self):
+        return self.__output_rules
+
     def validate_auth(self, req: WebhookRequest) -> None:
         """
         Validates auth headers in given Request for current Route.

--- a/webhook_gateway/routes/rules/input.py
+++ b/webhook_gateway/routes/rules/input.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from jsonpath_ng import parse
-from typing import final
+from typing import Optional, final
 
 from jsonpath_ng.jsonpath import DatumInContext
 
@@ -25,15 +25,15 @@ class InputRule:
         logger.debug(f"Loading rule {self.__name} with target {target}")
 
     @property
-    def target(self):
+    def target(self) -> Optional[str]:
         return self.__target
 
     @property
-    def config(self):
+    def config(self) -> Optional[dict]:
         return self.__config
 
     @property
-    def variable_name(self):
+    def variable_name(self) -> Optional[str]:
         return self.__variable_name
 
     @final

--- a/webhook_gateway/routes/rules/output.py
+++ b/webhook_gateway/routes/rules/output.py
@@ -1,5 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
+from typing import Optional
 from jsonpath_ng import parse
 import logging
 import requests
@@ -21,8 +22,20 @@ class OutputRule:
         }
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.__name
+
+    @property
+    def headers(self) -> Optional[dict]:
+        return self.__headers
+
+    @property
+    def body(self) -> dict:
+        return self.__body
+
+    @property
+    def variables(self) -> Optional[dict]:
+        return self.__variables
 
     def apply(self, req: WebhookRequest):
         logger.debug(f"apply: Calling {self.name}")

--- a/webhook_gateway/routes/service.py
+++ b/webhook_gateway/routes/service.py
@@ -6,6 +6,7 @@ from os.path import isfile
 from webhook_gateway.routes.rules.output import CallResult
 
 from .route import Route
+from .validator import validate_route
 from .exceptions import NonExistingRouteException
 from ..request import WebhookRequest
 
@@ -30,6 +31,11 @@ class RouteService:
     @property
     def route_count(self):
         return len(self.__routes)
+
+    def validate_routes(self):
+        # Validate routes configuration
+        for r in self.__routes.values():
+            validate_route(r)
 
     def get_route(self, route_name) -> Route:
         logger.debug(f"Looking for route {route_name}")

--- a/webhook_gateway/routes/validator.py
+++ b/webhook_gateway/routes/validator.py
@@ -1,0 +1,57 @@
+from os import environ as env
+from typing import Union
+
+from webhook_gateway.exceptions import ConfigurationException
+from .route import Route
+from .rules import OutputRule
+from ..context import INJECTION_PATTERN
+
+
+def validate_route(route: Route) -> None:
+    """
+    Validates a route's configuration.
+
+    Checks the coherence of context/environment variables declaration & usage.
+    """
+    var_names = [
+        v.variable_name for v in route.input_rules if v.variable_name is not None
+    ]
+
+    for r in route.output_rules:
+        validate_rule(route.name, r, var_names)
+
+
+def validate_rule(route_name: str, rule: OutputRule, var_names: list[str]) -> None:
+    if rule.headers:
+        for header_value in rule.headers.values():
+            validate_config(route_name, header_value, var_names)
+
+    validate_config(route_name, rule.body, var_names)
+
+    for var_name in rule.variables.values():
+        var_names.append(var_name)
+
+
+def validate_config(
+    route_name: str, config: Union[str, dict], var_names: list[str]
+) -> None:
+    if isinstance(config, dict):
+        for v in config.values():
+            validate_config(route_name, v, var_names)
+        return
+    elif not isinstance(config, str):
+        raise Exception(f"Invalid type {type(config)} for config object")
+
+    for source, var_name in INJECTION_PATTERN.findall(config):
+        if source == "context" and var_name not in var_names:
+            raise ConfigurationException(
+                f"Route {route_name} : variable {var_name} is used but never declared"
+            )
+        elif source == "env" and var_name not in env:
+            raise ConfigurationException(
+                f"Route {route_name} : environment variable {var_name} does not exist"
+            )
+        elif source not in ["context", "env"]:
+            raise ConfigurationException(
+                f"Route {route_name} : variable source {source} does not exist"
+            )


### PR DESCRIPTION
New feature :
A new module is added under webhook_gateway.routes : validator

This module adds configuration validation, to ensure the routes.json file is valid on startup.
For example, if
- a `#context[VAR_NAME]` is present in `output` rules
- no VAR_NAME variable is declared in `input` rules or in `output.context_variables` config part

then the app won't start, raising a `ConfigurationException`