### PR TITLE
core(routes): Change output configuration from list to dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,17 @@ You can configure the gateway using a single JSON file (usually named `routes.js
                 }
             }
         },
-        "output": [{
-            "name": "gitlab",
-            "url": "https://gitlab.com/api/v4/projects/my%2Fproject%2Fid/issues",
-            "headers": {
-                "Private-Token": "#env[GITLAB_API_TOKEN]"
-            },
-            "body": {
-                "title": "Hook received from #context[SOURCE_NAME]"
+        "output": {
+            "gitlab": {
+                "url": "https://gitlab.com/api/v4/projects/my%2Fproject%2Fid/issues",
+                "headers": {
+                    "Private-Token": "#env[GITLAB_API_TOKEN]"
+                },
+                "body": {
+                    "title": "Hook received from #context[SOURCE_NAME]"
+                }
             }
-        }]
+        }
     }
 }
 ```
@@ -118,8 +119,7 @@ The `context_variable` field defines the name of the context variable where the 
 ### Outputs
 The output rules describes which HTTP endpoints must be called when a request is received on the route endpoint.
 
-The `output` property is a JSON object list. Each object describe an endpoint to call. The available JSON object properties are :
-- `name` : The rule name (for logging/error handling)
+The `output` property is a JSON object. Each property of this object describes an endpoint to call. The property key is the output rule name (for logging/error handling), while the property value is a JSON object whose properties are :
 - `url` : webhook destination endpoint
 - `headers` (optional): the HTTP headers to set when sending a request to this endpoint. This property is a JSON object, with a key/value pair for each request header definition
 - `body`: the JSON body to be sent to this endpoint
@@ -133,3 +133,8 @@ You can use **Variables injection** in `headers` and `body` properties.
 You can inject 2 types of variables in output bodies and headers :
 - Environment variables : use `#env[VARIABLE_NAME]` syntax in your configuration
 - Context variables, when defined in `input` rules : use `#context[VARIABLE_NAME]` syntax in your configuration
+
+#### Output rules ordering
+The JSON file is loaded into a Python [`OrderedDict`][1], thus the output endpoints are called in the order they are declared in the `routes.json` file.
+
+[1]: https://docs.python.org/3/library/collections.html#collections.OrderedDict

--- a/routes.json
+++ b/routes.json
@@ -11,18 +11,19 @@
                 }
             }
         },
-        "output": [{
-            "name": "gitlab",
-            "url": "https://gitlab.com/api/v4/projects/lgatellier%2Ftest/issues",
-            "headers": {
-                "Private-Token": "#env[GITLAB_API_TOKEN]"
-            },
-            "body": {
-                "title": "Océane #context[TICKET_NUM]"
-            },
-            "context_variables": {
-                "$.id": "GITLAB_ISSUE_ID"
+        "output": {
+            "gitlab": {
+                "url": "https://gitlab.com/api/v4/projects/lgatellier%2Ftest/issues",
+                "headers": {
+                    "Private-Token": "#env[GITLAB_API_TOKEN]"
+                },
+                "body": {
+                    "title": "Océane #context[TICKET_NUM]"
+                },
+                "context_variables": {
+                    "$.id": "GITLAB_ISSUE_ID"
+                }
             }
-        }]
+        }
     }
 }

--- a/tests/routes/test_validator.py
+++ b/tests/routes/test_validator.py
@@ -91,22 +91,21 @@ class ConfigurationRouteValidatorTest(unittest.TestCase):
                     "$.num": {"equalsTo": "12345", "context_variable": "TICKET_NUM"}
                 }
             },
-            "output": [
-                {
-                    "name": "gitlab",
+            "output": {
+                "gitlab": {
                     "url": "https://gitlab.com/api/v4/projects/lgatellier%2Ftest/issues",
                     "headers": {"Private-Token": "#env[GITLAB_API_TOKEN]"},
                     "body": {"title": "Océane #context[TICKET_NUM]"},
                     "context_variables": {"$.id": "GITLAB_ISSUE_ID"},
                 }
-            ],
+            },
         }
         if auth_headers:
             route["auth_headers"].update(auth_headers)
         if input_body:
             route["input"]["body"].update(input_body)
         if output:
-            route["output"][0].update(output)
+            route["output"]["gitlab"].update(output)
 
         return Route("testroute", route)
 

--- a/webhook_gateway/routes/route.py
+++ b/webhook_gateway/routes/route.py
@@ -18,7 +18,7 @@ class Route:
         self.__input_rules = [
             parse_input_rule(k, v) for k, v in cfg["input"]["body"].items()
         ]
-        self.__output_rules = [OutputRule(v) for v in cfg["output"]]
+        self.__output_rules = [OutputRule(k, v) for k, v in cfg["output"].items()]
 
     @property
     def name(self) -> str:

--- a/webhook_gateway/routes/rules/output.py
+++ b/webhook_gateway/routes/rules/output.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 class OutputRule:
-    def __init__(self, obj: dict) -> None:
-        self.__name = obj["name"]
+    def __init__(self, name: str, obj: dict) -> None:
+        self.__name = name
         self.__url = obj["url"]
         self.__headers = obj["headers"]
         self.__body = obj["body"]

--- a/webhook_gateway/routes/service.py
+++ b/webhook_gateway/routes/service.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 import logging
 from os import access, R_OK
@@ -24,7 +25,7 @@ class RouteService:
 
         logger.info(f"Loading routes file '{config_file}'")
         with open(config_file, "r") as file:
-            cfg = json.load(file)
+            cfg = json.load(file, object_pairs_hook=OrderedDict)
             self.__routes = {k: Route(k, v) for k, v in cfg.items()}
         logger.info("RouteService is ready")
 


### PR DESCRIPTION
# What does this PR do ?
It simplifies the routes output configuration for the user. Instead of having a list of JSON objects with a `name` attribute on each object, we now have an object, its properties being `"name": {}` :
```json
"output": {
    "gitlab": {
        ...
    }
}
```

Resolves #36